### PR TITLE
Add PyTest for mapear_frases and CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,23 @@
+name: Python package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+    - name: Run tests
+      run: pytest -q

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Video Cutter v7
+
+This project includes tooling to cut videos automatically. Unit tests can be executed with [pytest](https://pytest.org).
+
+```bash
+pip install pytest
+pytest
+```
+
+Continuous integration runs these tests on GitHub Actions using the workflow defined in `.github/workflows/python-tests.yml`.

--- a/tests/test_mapear_frases.py
+++ b/tests/test_mapear_frases.py
@@ -1,0 +1,34 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from collections import namedtuple
+import pytest
+
+from utils.mapear_frases import mapear_frases
+
+Segment = namedtuple('Segment', ['start', 'end', 'text'])
+
+
+def test_mapear_frases_returns_expected_ranges():
+    segments = [
+        Segment(0.0, 10.0, 'Segment one text part one'),
+        Segment(10.0, 20.0, 'Segment two text part two'),
+        Segment(20.0, 30.0, 'Third segment has more text'),
+        Segment(30.0, 40.0, 'Final segment concluding text'),
+    ]
+
+    phrases = [
+        {'text': 'Segment one text part one Segment two text part two'},
+        {'text': 'Third segment has more text Final segment concluding text'},
+    ]
+
+    results = mapear_frases(phrases, segments)
+
+    expected = [
+        (0.0, 20.0),
+        (20.0, 40.0),
+    ]
+
+    assert len(results) == len(expected)
+    for mapping, (start, end) in zip(results, expected):
+        assert mapping['start'] >= start
+        assert mapping['end'] <= end


### PR DESCRIPTION
## Summary
- add README with basic testing instructions
- create GitHub Actions workflow to run pytest
- create unit test for utils.mapear_frases
- make utils a package for imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406f8a6efc83339b717495a52291d9